### PR TITLE
English books menu link too

### DIFF
--- a/Ayurveda.html
+++ b/Ayurveda.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/Ayurveda.html
+++ b/Ayurveda.html
@@ -37,7 +37,7 @@
                 </div>
                 <div class="menuItem">
                     <a href="boker.html" class="swedish displayNone" rel="noopener noreferrer">Böcker</a>
-                    
+                    <a href="boker.html"  class="english" rel="noopener noreferrer">Swedish books</a>
                 </div>
                 <div class="menuItem swedish displayNone">
                     <a href="Lankar.html">Länkar</a>

--- a/Ayurveda.html
+++ b/Ayurveda.html
@@ -37,7 +37,7 @@
                 </div>
                 <div class="menuItem">
                     <a href="boker.html" class="swedish displayNone" rel="noopener noreferrer">Böcker</a>
-                    <a href="boker.html"  class="english" rel="noopener noreferrer">Swedish books</a>
+                    <a href="boker.html"  class="english" rel="noopener noreferrer">Books (in Swedish)</a>
                 </div>
                 <div class="menuItem swedish displayNone">
                     <a href="Lankar.html">Länkar</a>

--- a/Ayurveda.html
+++ b/Ayurveda.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="sv">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/Kontakt.html
+++ b/Kontakt.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/Kontakt.html
+++ b/Kontakt.html
@@ -37,7 +37,7 @@
                 </div>
                 <div class="menuItem">
                     <a href="boker.html" class="swedish displayNone" rel="noopener noreferrer">Böcker</a>
-                    
+                    <a href="boker.html"  class="english" rel="noopener noreferrer">Swedish books</a>
                 </div>
                 <div class="menuItem swedish displayNone">
                     <a href="Lankar.html">Länkar</a>

--- a/Kontakt.html
+++ b/Kontakt.html
@@ -37,7 +37,7 @@
                 </div>
                 <div class="menuItem">
                     <a href="boker.html" class="swedish displayNone" rel="noopener noreferrer">Böcker</a>
-                    <a href="boker.html"  class="english" rel="noopener noreferrer">Swedish books</a>
+                    <a href="boker.html"  class="english" rel="noopener noreferrer">Books (in Swedish)</a>
                 </div>
                 <div class="menuItem swedish displayNone">
                     <a href="Lankar.html">Länkar</a>

--- a/Kontakt.html
+++ b/Kontakt.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="sv">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/Kurser.html
+++ b/Kurser.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="sv">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/Kurser.html
+++ b/Kurser.html
@@ -37,7 +37,7 @@
           </div>
           <div class="menuItem">
               <a href="boker.html" class="swedish displayNone" rel="noopener noreferrer">Böcker</a>
-              
+              <a href="boker.html"  class="english" rel="noopener noreferrer">Swedish books</a>
           </div>
           <div class="menuItem swedish displayNone">
             <a href="Lankar.html">Länkar</a>

--- a/Kurser.html
+++ b/Kurser.html
@@ -37,7 +37,7 @@
           </div>
           <div class="menuItem">
               <a href="boker.html" class="swedish displayNone" rel="noopener noreferrer">Böcker</a>
-              <a href="boker.html"  class="english" rel="noopener noreferrer">Swedish books</a>
+              <a href="boker.html"  class="english" rel="noopener noreferrer">Books (in Swedish)</a>
           </div>
           <div class="menuItem swedish displayNone">
             <a href="Lankar.html">Länkar</a>

--- a/Kurser.html
+++ b/Kurser.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/Lankar.html
+++ b/Lankar.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/Lankar.html
+++ b/Lankar.html
@@ -37,7 +37,7 @@
                 </div>
                 <div class="menuItem">
                     <a href="boker.html" class="swedish displayNone" rel="noopener noreferrer">Böcker</a>
-                    
+                    <a href="boker.html"  class="english" rel="noopener noreferrer">Swedish books</a>
                 </div>
                 <div class="menuItem swedish displayNone">
                     <a href="Lankar.html">Länkar</a>

--- a/Lankar.html
+++ b/Lankar.html
@@ -37,7 +37,7 @@
                 </div>
                 <div class="menuItem">
                     <a href="boker.html" class="swedish displayNone" rel="noopener noreferrer">Böcker</a>
-                    <a href="boker.html"  class="english" rel="noopener noreferrer">Swedish books</a>
+                    <a href="boker.html"  class="english" rel="noopener noreferrer">Books (in Swedish)</a>
                 </div>
                 <div class="menuItem swedish displayNone">
                     <a href="Lankar.html">Länkar</a>

--- a/Lankar.html
+++ b/Lankar.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="sv">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/PT-konsultation.html
+++ b/PT-konsultation.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="sv">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/PT-konsultation.html
+++ b/PT-konsultation.html
@@ -38,7 +38,7 @@
           </div>
           <div class="menuItem">
               <a href="boker.html" class="swedish displayNone" rel="noopener noreferrer">Böcker</a>
-              <a href="boker.html"  class="english" rel="noopener noreferrer">Swedish books</a>
+              <a href="boker.html"  class="english" rel="noopener noreferrer">Books (in Swedish)</a>
           </div>
           <div class="menuItem swedish displayNone">
               <a href="Lankar.html">Länkar</a>

--- a/PT-konsultation.html
+++ b/PT-konsultation.html
@@ -38,7 +38,7 @@
           </div>
           <div class="menuItem">
               <a href="boker.html" class="swedish displayNone" rel="noopener noreferrer">Böcker</a>
-              
+              <a href="boker.html"  class="english" rel="noopener noreferrer">Swedish books</a>
           </div>
           <div class="menuItem swedish displayNone">
               <a href="Lankar.html">Länkar</a>

--- a/PT-konsultation.html
+++ b/PT-konsultation.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/VaraForfattare.html
+++ b/VaraForfattare.html
@@ -35,7 +35,7 @@
             </div>
             <div class="menuItem">
                 <a href="boker.html" class="swedish displayNone" rel="noopener noreferrer">Böcker</a>
-                
+                <a href="boker.html"  class="english" rel="noopener noreferrer">Swedish books</a>                
             </div>
             <div class="menuItem swedish displayNone">
                 <a href="Lankar.html">Länkar</a>

--- a/VaraForfattare.html
+++ b/VaraForfattare.html
@@ -35,7 +35,7 @@
             </div>
             <div class="menuItem">
                 <a href="boker.html" class="swedish displayNone" rel="noopener noreferrer">Böcker</a>
-                <a href="boker.html"  class="english" rel="noopener noreferrer">Swedish books</a>                
+                <a href="boker.html"  class="english" rel="noopener noreferrer">Books (in Swedish)</a>                
             </div>
             <div class="menuItem swedish displayNone">
                 <a href="Lankar.html">Länkar</a>

--- a/boker.html
+++ b/boker.html
@@ -54,7 +54,8 @@
             <div id="content">
                 <!-- Insert content below -->
 
-                <h1>Våra böcker om Ayurveda/hälsa</h1>
+                <h1 class="swedish displayNone">Våra böcker om Ayurveda/hälsa</h1>
+                <h1 class="english">Our books in Swedish</h1>
 
                 <h2 class="subheader">Böckerna ges ut av vårt förlag Syneidos Kvalitetslitteratur som ger ut böcker om visdom, skönhet och hälsa.</h2>
 

--- a/boker.html
+++ b/boker.html
@@ -37,7 +37,7 @@
             </div>
             <div class="menuItem">
                 <a href="boker.html" class="swedish displayNone" rel="noopener noreferrer">Böcker</a>
-                
+                <a href="boker.html"  class="english" rel="noopener noreferrer">Swedish books</a>
             </div>
             <div class="menuItem swedish displayNone">
                 <a href="Lankar.html">Länkar</a>

--- a/boker.html
+++ b/boker.html
@@ -37,7 +37,7 @@
             </div>
             <div class="menuItem">
                 <a href="boker.html" class="swedish displayNone" rel="noopener noreferrer">Böcker</a>
-                <a href="boker.html"  class="english" rel="noopener noreferrer">Swedish books</a>
+                <a href="boker.html"  class="english" rel="noopener noreferrer">Books (in Swedish)</a>
             </div>
             <div class="menuItem swedish displayNone">
                 <a href="Lankar.html">Länkar</a>

--- a/boker.html
+++ b/boker.html
@@ -55,7 +55,7 @@
                 <!-- Insert content below -->
 
                 <h1 class="swedish displayNone">Våra böcker om Ayurveda/hälsa</h1>
-                <h1 class="english">Our books in Swedish</h1>
+                <h1 class="english">Our books (in Swedish)</h1>
 
                 <h2 class="subheader">Böckerna ges ut av vårt förlag Syneidos Kvalitetslitteratur som ger ut böcker om visdom, skönhet och hälsa.</h2>
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
                 </div>
                 <div class="menuItem">
                     <a href="boker.html" class="swedish displayNone" rel="noopener noreferrer">Böcker</a>
-                    
+                    <a href="boker.html"  class="english" rel="noopener noreferrer">Swedish books</a>
                 </div>
                 <div class="menuItem swedish displayNone">
                     <a href="Lankar.html">Länkar</a>

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
                 </div>
                 <div class="menuItem">
                     <a href="boker.html" class="swedish displayNone" rel="noopener noreferrer">Böcker</a>
-                    <a href="boker.html"  class="english" rel="noopener noreferrer">Swedish books</a>
+                    <a href="boker.html"  class="english" rel="noopener noreferrer">Books (in Swedish)</a>
                 </div>
                 <div class="menuItem swedish displayNone">
                     <a href="Lankar.html">Länkar</a>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="sv">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/js/responsive.js
+++ b/js/responsive.js
@@ -1,5 +1,6 @@
 'use strict'
 ;(() => {
+  setHTMLLanguage()
   isSwedishLanguage() && translate()
 
   const width = getScreenWidth()
@@ -17,6 +18,10 @@
     }
   }
 })()
+
+function setHTMLLanguage() {
+  document.documentElement.lang = navigator.language
+}
 
 function isSwedishLanguage() {
   const language = (

--- a/js/responsive.js
+++ b/js/responsive.js
@@ -1,6 +1,5 @@
 'use strict'
 ;(() => {
-  setHTMLLanguage()
   isSwedishLanguage() && translate()
 
   const width = getScreenWidth()
@@ -18,10 +17,6 @@
     }
   }
 })()
-
-function setHTMLLanguage() {
-  document.documentElement.lang = navigator.language
-}
 
 function isSwedishLanguage() {
   const language = (


### PR DESCRIPTION
Someone who understands Swedish might still have English as the language on their device. Therefore, there should still be a link to the books on the English site as well.

The menu link here in English appears as "Swedish books". 